### PR TITLE
Make default options depend on EPNMODE, add BEAMTYPE option

### DIFF
--- a/common/setenv.sh
+++ b/common/setenv.sh
@@ -9,9 +9,7 @@ fi
 
 if [ -z "$NTIMEFRAMES" ];   then export NTIMEFRAMES=1; fi              # Number of time frames to process
 if [ -z "$TFDELAY" ];       then export TFDELAY=100; fi                # Delay in seconds between publishing time frames
-if [ -z "$NGPUS" ];         then export NGPUS=1; fi                    # Number of GPUs to use, data distributed round-robin
 if [ -z "$GPUTYPE" ];       then export GPUTYPE=CPU; fi                # GPU Tracking backend to use, can be CPU / CUDA / HIP / OCL / OCL2
-if [ -z "$SHMSIZE" ];       then export SHMSIZE=$(( 8 << 30 )); fi     # Size of shared memory for messages
 if [ -z "$DDSHMSIZE" ];     then export DDSHMSIZE=$(( 8 << 10 )); fi   # Size of shared memory for DD Input
 if [ -z "$GPUMEMSIZE" ];    then export GPUMEMSIZE=$(( 24 << 30 )); fi # Size of allocated GPU memory (if GPUTYPE != CPU)
 if [ -z "$HOSTMEMSIZE" ];   then export HOSTMEMSIZE=0; fi              # Size of allocated host memory for GPU reconstruction (0 = default)
@@ -20,18 +18,29 @@ if [ -z "$SAVECTF" ];       then export SAVECTF=0; fi                  # Save th
 if [ -z "$SYNCMODE" ];      then export SYNCMODE=0; fi                 # Run only reconstruction steps of the synchronous reconstruction
 if [ -z "$NUMAID" ];        then export NUMAID=0; fi                   # SHM segment id to use for shipping data as well as set of GPUs to use (use 0 / 1 for 2 NUMA domains)
 if [ -z "$NUMAGPUIDS" ];    then export NUMAGPUIDS=0; fi               # NUMAID-aware GPU id selection
-if [ -z "$EXTINPUT" ];      then export EXTINPUT=0; fi                 # Receive input from raw FMQ channel instead of running o2-raw-file-reader
 if [ -z "$CTFINPUT" ];      then export CTFINPUT=0; fi                 # Read input from CTF (incompatible to EXTINPUT=1)
 if [ -z "$NHBPERTF" ];      then export NHBPERTF=128; fi               # Time frame length (in HBF)
 if [ -z "$GLOBALDPLOPT" ];  then export GLOBALDPLOPT=; fi              # Global DPL workflow options appended at the end
-if [ -z "$EPNPIPELINES" ];  then export EPNPIPELINES=0; fi             # Set default EPN pipeline multiplicities
 if [ -z "$SEVERITY" ];      then export SEVERITY="info"; fi            # Log verbosity
-if [ -z "$SHMTHROW" ];      then export SHMTHROW=1; fi                 # Throw exception when running out of SHM
 if [ -z "$NORATELOG" ];     then export NORATELOG=1; fi                # Disable FairMQ Rate Logging
 if [ -z "$INRAWCHANNAME" ]; then export INRAWCHANNAME=stfb-to-dpl; fi  # Raw channel name used to communicate with DataDistribution
 if [ -z "$WORKFLOWMODE" ];  then export WORKFLOWMODE=run; fi           # Workflow mode, must be run, print, od dds
 if [ -z "$FILEWORKDIR" ];   then export FILEWORKDIR=`pwd`; fi          # Override folder where to find grp, etc.
 if [ -z "$EPNMODE" ];       then export EPNMODE=0; fi                  # Is this workflow supposed to run on EPN? Will enable InfoLogger / metrics / ...
+if [ -z "$BEAMTYPE" ];      then export BEAMTYPE=PbPb; fi              # Beam type, must be PbPb, pp, pPb, cosmic, technical
+if [ $EPNMODE == 0 ]; then
+  if [ -z "$SHMSIZE" ];       then export SHMSIZE=$(( 8 << 30 )); fi   # Size of shared memory for messages
+  if [ -z "$NGPUS" ];         then export NGPUS=1; fi                  # Number of GPUs to use, data distributed round-robin
+  if [ -z "$EXTINPUT" ];      then export EXTINPUT=0; fi               # Receive input from raw FMQ channel instead of running o2-raw-file-reader
+  if [ -z "$EPNPIPELINES" ];  then export EPNPIPELINES=0; fi           # Set default EPN pipeline multiplicities
+  if [ -z "$SHMTHROW" ];      then export SHMTHROW=1; fi               # Throw exception when running out of SHM
+else # Defaults when running on the EPN
+  if [ -z "$SHMSIZE" ];       then export SHMSIZE=$(( 256 << 30 )); fi
+  if [ -z "$NGPUS" ];         then export NGPUS=4; fi
+  if [ -z "$EXTINPUT" ];      then export EXTINPUT=1; fi
+  if [ -z "$EPNPIPELINES" ];  then export EPNPIPELINES=1; fi
+  if [ -z "$SHMTHROW" ];      then export SHMTHROW=1; fi               # NOTE: SHMTHROW SHOULD BE 0 FOR EPN, BUT IS =1 FOR TESTS DURING COMMISSIONING WHILE WE HAVE NO MEMORY MONITORING
+fi
 # Detectors used in the workflow / enabled parameters
 if [ -z "${WORKFLOW_DETECTORS+x}" ] || [ "0$WORKFLOW_DETECTORS" == "0ALL" ]; then export WORKFLOW_DETECTORS="ITS,MFT,TPC,TOF,FT0,MID,EMC,PHS,CPV,ZDC,FDD,HMP,FV0,TRD,MCH"; fi
 if [ -z "${WORKFLOW_DETECTORS_QC+x}" ] || [ "0$WORKFLOW_DETECTORS_QC" == "0ALL" ]; then export WORKFLOW_DETECTORS_QC=$WORKFLOW_DETECTORS; fi

--- a/production/production.desc
+++ b/production/production.desc
@@ -1,2 +1,2 @@
-synchronous-workflow:  "DataDistribution QualityControl" reco,128,128,"EXTINPUT=1 SYNCMODE=1 NUMAGPUIDS=1 NUMAID=0 SHMSIZE=128000000000 EPNPIPELINES=1 SHMTHROW=0 INFOLOGGER_SEVERITY=warning production/dpl-workflow.sh" reco,128,128,"EXTINPUT=1 SYNCMODE=1 NUMAGPUIDS=1 NUMAID=1 SHMSIZE=128000000000 EPNPIPELINES=1 SHMTHROW=0 INFOLOGGER_SEVERITY=warning production/dpl-workflow.sh"
-synchronous-workflow-1numa:  "DataDistribution QualityControl" reco,128,128,"EXTINPUT=1 SYNCMODE=1 NUMAGPUIDS=1 NUMAID=0 SHMSIZE=128000000000 EPNPIPELINES=1 SHMTHROW=0 INFOLOGGER_SEVERITY=warning production/dpl-workflow.sh"
+synchronous-workflow:  "DataDistribution QualityControl" reco,128,128,"SYNCMODE=1 NUMAGPUIDS=1 NUMAID=0 SHMSIZE=128000000000 production/dpl-workflow.sh" reco,128,128,"SYNCMODE=1 NUMAGPUIDS=1 NUMAID=1 SHMSIZE=128000000000 production/dpl-workflow.sh"
+synchronous-workflow-1numa:  "DataDistribution QualityControl" reco,128,128,"SYNCMODE=1 production/dpl-workflow.sh"


### PR DESCRIPTION
@shahor02 : This should reduce the bloat of default settings, basically only SYNCMODE is still needed.
The `synchronous-workflow-1numa` is now quite simple.

Btw, why do you create a description file with all detector combinations.
You anyway need to iterate over the options in your run_ext.sh. Then you could also provide the detector combinations via env variables from there.
