### PR TITLE
Can use WORKFLOWMODE=print for tools/parse / run.sh

### DIFF
--- a/production/dpl-workflow.sh
+++ b/production/dpl-workflow.sh
@@ -395,7 +395,7 @@ WORKFLOW+="o2-dpl-run $ARGS_ALL $GLOBALDPLOPT"
 # ---------------------------------------------------------------------------------------------------------------------
 # Run / create / print workflow
 if [ $WORKFLOWMODE == "print" ]; then
-  echo Workflow command:
+  echo "#Workflow command:"
   echo $WORKFLOW | sed "s/| */|\n/g"
 else
   # Execute the command we have assembled

--- a/production/dpl-workflow.sh
+++ b/production/dpl-workflow.sh
@@ -226,7 +226,7 @@ N_ITSRAWDEC=$((6 * 30 / $RECO_NUM_NODES_WORKFLOW_CMP > $N_ITSRAWDEC ? 6 * 30 / $
 N_MFTRAWDEC=$((6 * 30 / $RECO_NUM_NODES_WORKFLOW_CMP > $N_MFTRAWDEC ? 6 * 30 / $RECO_NUM_NODES_WORKFLOW_CMP : $N_MFTRAWDEC))
 N_ITSTRK=$((2 * 30 / $RECO_NUM_NODES_WORKFLOW_CMP > $N_ITSTRK ? 2 * 30 / $RECO_NUM_NODES_WORKFLOW_CMP : $N_ITSTRK))
 N_MFTTRK=$((2 * 30 / $RECO_NUM_NODES_WORKFLOW_CMP > $N_MFTTRK ? 2 * 30 / $RECO_NUM_NODES_WORKFLOW_CMP : $N_MFTTRK))
-N_CTPRAWDEC=$((30 / $RECO_NUM_NODES_WORKFLOW_CMP > N_CTPRAWDEC ? 30 / $RECO_NUM_NODhas_detector_flp_processing CPVES_WORKFLOW_CMP : $N_CTPRAWDEC))
+N_CTPRAWDEC=$((30 / $RECO_NUM_NODES_WORKFLOW_CMP > N_CTPRAWDEC ? 30 / $RECO_NUM_NODES_WORKFLOW_CMP : $N_CTPRAWDEC))
 # Apply external multiplicity factors
 N_TPCTRK=$((N_TPCTRK * $N_F_REST))
 N_TPCITS=$((N_TPCITS * $N_F_REST))
@@ -292,8 +292,7 @@ if [ $CTFINPUT == 0 ]; then
   if has_detector TPC && [ $EPNMODE == 1 ]; then
     GPU_INPUT=zsonthefly
     WORKFLOW+="o2-tpc-raw-to-digits-workflow $ARGS_ALL --configKeyValues \"$ARGS_ALL_CONFIG\" --input-spec \"A:TPC/RAWDATA;dd:FLP/DISTSUBTIMEFRAME/0\" --remove-duplicates --pipeline tpc-raw-to-digits-0:$N_TPCRAWDEC | "
-    WORKFLOW+="o2-tpc-reco-workflow $ARGS_ALL --configKeyValues \"$ARGS[ -z "$QC_JSON_FT0" ] && QC_JSON_FT0=/home/afurs/work/epn/configs/qc/ft0-digits-qc-ds.json
-[ -z "$QC_JSON_FV0" ] && QC_JSON_FV0=/home/afurs/work/epn/configs/qc/fv0-digits-qc-ds.json_ALL_CONFIG\" --input-type digitizer --output-type zsraw,disable-writer --pipeline tpc-zsEncoder:$N_TPCRAWDEC | "
+    WORKFLOW+="o2-tpc-reco-workflow $ARGS_ALL --configKeyValues \"$ARGS_ALL_CONFIG\" --input-type digitizer --output-type zsraw,disable-writer --pipeline tpc-zsEncoder:$N_TPCRAWDEC | "
   fi
   has_detector ITS && WORKFLOW+="o2-itsmft-stf-decoder-workflow $ARGS_ALL --configKeyValues \"$ARGS_ALL_CONFIG\" --dict-file \"${ITSCLUSDICT}\" --nthreads ${NITSDECTHREADS} --pipeline its-stf-decoder:$N_ITSRAWDEC | "
   has_detector MFT && WORKFLOW+="o2-itsmft-stf-decoder-workflow $ARGS_ALL --configKeyValues \"$ARGS_ALL_CONFIG\" --dict-file \"${MFTCLUSDICT}\" --nthreads ${NMFTDECTHREADS} --pipeline mft-stf-decoder:$N_MFTRAWDEC ${MFTDEC_CONFIG} --runmft true | "

--- a/production/full-system-test.desc
+++ b/production/full-system-test.desc
@@ -1,3 +1,3 @@
 #Full system test workflows
-full-system-test-async: O2PDPSuite/latest reco,128,126,"CTFINPUT=1 SHMSIZE=64000000000 HOSTMEMSIZE=30000000000 production/full-system-test/dpl-workflow.sh"
-full-system-test-sync:  O2PDPSuite/latest reco,128,126,"SYNCMODE=1 SHMSIZE=64000000000 HOSTMEMSIZE=30000000000 production/full-system-test/dpl-workflow.sh"
+full-system-test-async: O2PDPSuite reco,128,126,"CTFINPUT=1 SHMSIZE=64000000000 HOSTMEMSIZE=30000000000 production/full-system-test/dpl-workflow.sh"
+full-system-test-sync:  O2PDPSuite reco,128,126,"SYNCMODE=1 SHMSIZE=64000000000 HOSTMEMSIZE=30000000000 production/full-system-test/dpl-workflow.sh"

--- a/production/no-processing.desc
+++ b/production/no-processing.desc
@@ -1,2 +1,2 @@
 # Empty workflow for no processing at all
-no-processing: "DataDistribution"
+no-processing: "O2PDPSuite"

--- a/production/production.desc
+++ b/production/production.desc
@@ -1,2 +1,2 @@
-synchronous-workflow: "DataDistribution QualityControl" reco,128,128,"SYNCMODE=1 NUMAGPUIDS=1 NUMAID=0 SHMSIZE=128000000000 production/dpl-workflow.sh" reco,128,128,"SYNCMODE=1 NUMAGPUIDS=1 NUMAID=1 SHMSIZE=128000000000 production/dpl-workflow.sh"
-synchronous-workflow-1numa: "DataDistribution QualityControl" reco,128,128,"SYNCMODE=1 production/dpl-workflow.sh"
+synchronous-workflow: "O2PDPSuite" reco,128,128,"SYNCMODE=1 NUMAGPUIDS=1 NUMAID=0 SHMSIZE=128000000000 production/dpl-workflow.sh" reco,128,128,"SYNCMODE=1 NUMAGPUIDS=1 NUMAID=1 SHMSIZE=128000000000 production/dpl-workflow.sh"
+synchronous-workflow-1numa: "O2PDPSuite" reco,128,128,"SYNCMODE=1 production/dpl-workflow.sh"

--- a/tools/epn/run.sh
+++ b/tools/epn/run.sh
@@ -5,22 +5,22 @@ export DDMODE=processing                                             # DataDistr
 
 # Use these settings to fetch the Workflow Repository using a hash / tag
 #export GEN_TOPO_HASH=1                                              # Fetch O2DataProcessing repository using a git hash
-#export GEN_TOPO_SOURCE=v0.5                                         # Git hash to fetch
+#export GEN_TOPO_SOURCE=v0.13                                        # Git hash to fetch
 
 # Use these settings to specify a path to the workflow repository in your home dir
 export GEN_TOPO_HASH=0                                               # Specify path to O2DataProcessing repository
 export GEN_TOPO_SOURCE=/home/drohr/alice/O2DataProcessing            # Path to O2DataProcessing repository
 
-export GEN_TOPO_LIBRARY_FILE=testing/detectors/TPC/workflows.desc    # Topology description library file to load
-export GEN_TOPO_WORKFLOW_NAME=ctf-and-display                        # Name of workflow in topology description library
+export GEN_TOPO_LIBRARY_FILE=production/production.desc              # Topology description library file to load
+export GEN_TOPO_WORKFLOW_NAME=synchronous-workflow                   # Name of workflow in topology description library
 export WORKFLOW_DETECTORS=ALL                                        # Optional parameter for the workflow: Detectors to run reconstruction for (comma-separated list)
-export WORKFLOW_DETECTORS_QC=                                        # Optional parameter for the workflow: Detectors to run QC for
-export WORKFLOW_DETECTORS_CALIB=                                     # Optional parameters for the workflow: Detectors to run calibration for
-export WORKFLOW_DETECTORS_RECO=                                      # Optional parameters for the workflow: Detectors to run calibration for
-export WORKFLOW_DETECTORS_FLP_PROCESSING=                            # Optional parameters for the workflow: Detectors to run calibration for
-export WORKFLOW_PARAMETERS=                                          # Additional paramters for the workflow
+export WORKFLOW_DETECTORS_QC=ALL                                     # Optional parameter for the workflow: Detectors to run QC for
+export WORKFLOW_DETECTORS_CALIB=ALL                                  # Optional parameters for the workflow: Detectors to run calibration for
+export WORKFLOW_DETECTORS_RECO=ALL                                   # Optional parameters for the workflow: Detectors to run calibration for
+export WORKFLOW_DETECTORS_FLP_PROCESSING=ALL                         # Optional parameters for the workflow: Detectors to run calibration for
+export WORKFLOW_PARAMETERS=QC,CALIB,GPU,CTF,EVENT_DISPLAY            # Additional paramters for the workflow
 export RECO_NUM_NODES_OVERRIDE=0                                     # Override the number of EPN compute nodes to use (default is specified in description library file)
-export NHBPERTF=256                                                  # Number of HBF per TF
+export NHBPERTF=128                                                  # Number of HBF per TF
 export MULTIPLICITY_FACTOR_RAWDECODERS=1                             # Factor to scale number of raw decoders with
 export MULTIPLICITY_FACTOR_CTFENCODERS=1                             # Factor to scale number of CTF encoders with
 export MULTIPLICITY_FACTOR_REST=1                                    # Factor to scale number of other processes with

--- a/tools/parse
+++ b/tools/parse
@@ -27,7 +27,12 @@ if not "DDWORKFLOW" in os.environ:
 
 print("Using topology", sys.argv[2], "of library", sys.argv[1])
 
-os.environ['WORKFLOWMODE'] = 'dds'
+if 'WORKFLOWMODE' in os.environ:
+    if not os.environ['WORKFLOWMODE'] in ['dds', 'print']:
+        print("Invalid WORKFLOWMODE provided")
+        raise
+else:
+    os.environ['WORKFLOWMODE'] = 'dds'
 if 'GLOBALDPLOPT' in os.environ:
     os.environ['GLOBALDPLOPT'] += " -b"
 else:
@@ -108,20 +113,27 @@ for line in f:
                     raise
             if reco_num_nodes_override > 0:
                 reconodes = reco_num_nodes_override
-            odccommand = "odc-epn-topo"
-            if reconodes:
-                odccommand += " --dd " + os.environ['DDWORKFLOW']
-            if len(recoworkflows):
-                odccommand += " --reco " + " ".join(recoworkflows)
-            odccommand += " --n " + str(reconodes)
-            if len(calibworkflows):
-                odccommand += " --calib " + " ".join(calibworkflows)
-            if args[1] != "":
-                odccommand += " --prependexe \"module load " + args[1] + "; \""
-            odccommand += " -o " + sys.argv[3]
-            if os.system(odccommand) != 0:
-                print("\nError running odc: ", odccommand)
-                raise
+            if os.environ['WORKFLOWMODE'] == 'dds':
+                odccommand = "odc-epn-topo"
+                if reconodes:
+                    odccommand += " --dd " + os.environ['DDWORKFLOW']
+                if len(recoworkflows):
+                    odccommand += " --reco " + " ".join(recoworkflows)
+                odccommand += " --n " + str(reconodes)
+                if len(calibworkflows):
+                    odccommand += " --calib " + " ".join(calibworkflows)
+                if args[1] != "":
+                    odccommand += " --prependexe \"module load " + args[1] + "; \""
+                odccommand += " -o " + sys.argv[3]
+                if os.system(odccommand) != 0:
+                    print("\nError running odc: ", odccommand)
+                    raise
+            else:
+                outf = open(sys.argv[3], "w+")
+                for i in recoworkflows:
+                    outf.write("# RECO workflow\n\n" + open(i, 'r').read() + "\n\n")
+                for i in calibworkflows:
+                    outf.write("# CALIB workflow\n\n" + open(i, 'r').read() + "\n\n")
         print("Done")
         exit(0)
 


### PR DESCRIPTION
@shahor02 : With this version you can generate workflow scripts using run.sh (or tools/parse).
Just export `WORKFLOWMODE=print`, if there are multiple workflows it will collect all commands to one file.

Output works in the same way as for DDS XMLs, i.e. `/home/epn/pdp/gen_topo.sh` will write it to stdout, and run.sh will then pipe it to the file you configure.