### PR TITLE
Set GPU_NUM_MEM_REG_CALLBACKS on EPN

### DIFF
--- a/production/dpl-workflow.sh
+++ b/production/dpl-workflow.sh
@@ -113,6 +113,7 @@ if [ $EPNMODE == 1 ]; then
   MIDDEC_CONFIG+=" --feeId-config-file \"$MID_FEEID_MAP\""
   # Options for decoding current TRD real raw data (not needed for data converted from MC)
   if [ -z $TRD_DECODER_OPTIONS ]; then TRD_DECODER_OPTIONS=" --tracklethcheader 2  --ignore-digithcheader --halfchamberwords 2 --halfchambermajor 33 "; fi
+  if [ $EXTINPUT == 1 ] && [ $GPUTYPE != "CPU" ] && [ -z "GPU_NUM_MEM_REG_CALLBACKS" ]; then GPU_NUM_MEM_REG_CALLBACKS=4; fi
 fi
 
 if [ $GPUTYPE == "HIP" ]; then

--- a/production/production.desc
+++ b/production/production.desc
@@ -1,2 +1,2 @@
-synchronous-workflow: "O2PDPSuite" reco,128,128,"SYNCMODE=1 NUMAGPUIDS=1 NUMAID=0 SHMSIZE=128000000000 production/dpl-workflow.sh" reco,128,128,"SYNCMODE=1 NUMAGPUIDS=1 NUMAID=1 SHMSIZE=128000000000 production/dpl-workflow.sh"
+synchronous-workflow: "O2PDPSuite" reco,128,128,"GPU_NUM_MEM_REG_CALLBACKS=5 SYNCMODE=1 NUMAGPUIDS=1 NUMAID=0 SHMSIZE=128000000000 production/dpl-workflow.sh" reco,128,128,"GPU_NUM_MEM_REG_CALLBACKS=5 SYNCMODE=1 NUMAGPUIDS=1 NUMAID=1 SHMSIZE=128000000000 production/dpl-workflow.sh"
 synchronous-workflow-1numa: "O2PDPSuite" reco,128,128,"SYNCMODE=1 production/dpl-workflow.sh"


### PR DESCRIPTION
@shahor02 : This should make sure that the EPN doesn't go to ready before the SHM has been fully registered on GPU. But we have to test it in a run with TPC and GPU on the EPN.