### PR TITLE
Disable SHM throw on the EPN

### DIFF
--- a/common/setenv.sh
+++ b/common/setenv.sh
@@ -51,7 +51,7 @@ else # Defaults when running on the EPN
   if [ -z "$NGPUS" ];         then export NGPUS=4; fi
   if [ -z "$EXTINPUT" ];      then export EXTINPUT=1; fi
   if [ -z "$EPNPIPELINES" ];  then export EPNPIPELINES=1; fi
-  if [ -z "$SHMTHROW" ];      then export SHMTHROW=1; fi               # NOTE: SHMTHROW SHOULD BE 0 FOR EPN, BUT IS =1 FOR TESTS DURING COMMISSIONING WHILE WE HAVE NO MEMORY MONITORING
+  if [ -z "$SHMTHROW" ];      then export SHMTHROW=0; fi
   if [ -z "${WORKFLOW_DETECTORS_FLP_PROCESSING+x}" ]; then export WORKFLOW_DETECTORS_FLP_PROCESSING="TOF"; fi # Current default in sync processing is that FLP processing is only enabled for TOF
 fi
 # Some more options for running on the EPN


### PR DESCRIPTION
@shahor02 : I propose we disable the exception in case we run out of SHM memory.

Actually it doesn't really change the behavior on the global view. When the SHM is full, the chain is stuck, so the EPN will stop processing data. The same happens when the process throws the exception and exits. But the error messages from the exception are found by shifters / experts, and they are confused and assume this is the original error, while it is only a symptom. So I don't see how this helps.

Could we change the settings and recreate the workflows with this?
What do you think?