### PR TITLE
Update the common QC parameters

### DIFF
--- a/production/qc_global.json
+++ b/production/qc_global.json
@@ -3,7 +3,7 @@
     "config": {
       "database": {
         "implementation": "CCDB",
-        "host": "qcdb.cern.ch:8083",
+        "host": "ali-qcdb.cern.ch:8083",
         "username": "not_applicable",
         "password": "not_applicable",
         "name": "not_applicable"
@@ -16,10 +16,10 @@
         "url": "infologger:///debug?qc"
       },
       "consul": {
-        "url": "http://consul-test.cern.ch:8500"
+        "url": ""
       },
       "conditionDB": {
-        "url": "ccdb-test.cern.ch:8080"
+        "url": "http://localhost:8084"
       },
       "infologger": {
         "filterDiscardDebug": "true",


### PR DESCRIPTION
It includes the new QCDB address, getting rid of the test consul instance (which should not be used here) and the correct CCDB endpoint